### PR TITLE
provide file to adapter via data object

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -42,6 +42,8 @@ module.exports = function(file, cb) {
         parseTasks[lib] = function(cb) {
           // Store the original value of the YML property so it can be accessed later if needed
           page._adapterData[lib] = page[lib];
+          // Store the file on the adapter in case it needs it  
+          page[lib]._file = file;
 
           // Then find the configuration for the adapter and run it
           var config = extend(_this.adapters[lib].config, _this.options.config[lib] || {});
@@ -55,7 +57,7 @@ module.exports = function(file, cb) {
     for (var i in results) {
       page[i] = results[i];
     }
-    
+
     _this.tree.push(page);
     cb(null, page);
   });


### PR DESCRIPTION
It's really useful to have the markdown file being processed to be provided to the adapter.  If your adapter references a file for example, (we're using a plugin that gives snippets), this change allows that adapter to use parse relative paths instead of absolute (and repeating) ones.   
